### PR TITLE
Integrate Material UI component Button into Olimpo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ class Example extends Component {
   }
 }
 ```
-
+**Obs.:** When use `materialui` framework component, all properties available on [Material-UI](https://material-ui.com/components/buttons/) documentation can be use.
 ## Development
 To import the module from local files, you need to import `olimpo` on your project then run the following commands:
 ```

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -17,19 +17,12 @@ const App = () => {
   }
   return ( 
     <div> 
-      {/* <ExampleComponent text="Create React Library Example 😄" /> */}
-
       <Button 
-        text="My text" 
-        onClick={myOnClickFunction}
-        onMouseOver={myOnMouseOverFunction}
-        size={"large"}
-        disabled={false}
-        color={'red'}
-        textColor={'yellow'}
-        framework={"antd"}/> 
-        
-
+        variant="outlined"
+        color="primary"
+        framework={'materialui'}>
+          My button
+      </Button> 
     </div> 
   );
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "microbundle-crl --no-compress --format modern,cjs",
-    "start": "microbundle-crl watch --no-compress --format modern,cjs",
+    "start": "microbundle-crl watch --no-compress --format modern,cjs --external=react,react-dom,react-is",
     "prepare": "run-s build",
     "test": "run-s test:unit test:lint test:build && eslint .",
     "test:build": "run-s build",

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { Button as MaterialButton } from '@material-ui/core';
 import './css/button.css'
 
 export default class Button extends Component {
@@ -51,7 +52,7 @@ export default class Button extends Component {
         } 
     }
 
-    render() {   
+    renderDefaultButton = () => {
         return (
             <button 
             className="button"
@@ -65,10 +66,37 @@ export default class Button extends Component {
             onClick={this.onClick()}
             onMouseOver={this.onMouseOver()}
             >
-                {!this.props.text ? 'Placeholder' : this.props.text}
-            
+                {this.props.text || 'Placeholder'}
             </button>
             
+        );        
+    }
+    
+    renderMaterialuiButton = () => {
+        return (
+            <MaterialButton 
+            onClick={this.onClick()}
+            onMouseOver={this.onMouseOver()}
+            {...this.props}>
+                {this.props.text || 'Placeholder'}
+            </MaterialButton>
+        );        
+    }
+    render() {  
+        let button;
+        switch (this.props.framework) {
+            case 'materialui':
+                button = this.renderMaterialuiButton();
+                break;
+            default:
+                button = this.renderDefaultButton();
+                break;
+        }
+
+        return (
+            <div>
+                { button }
+            </div> 
         );
     }
 }


### PR DESCRIPTION
This pull request integrate Material UI component Button into Olimpo. The framework property can now be called using `materialui` as value. When using the component with this property being used the user can use all Material UI properties.